### PR TITLE
Same keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ You finally scored a record deal.
 
 ## Usage guide
 
+### Assert two records have the same keys with `SameKeys`
+
+```purescript
+-- An example of a function that requires `{|r1}` and `{|r2}` to have the same keys
+sameKeys :: forall r1 r2. SameKeys r1 r2 => {|r1} -> {|r2} -> Unit
+sameKeys _ _ = unit
+let _ = sameKeys { b: "hi", a: 4, c: 4 } { b: "hu", a: "ha" }
+-- Won't compile: The key "c" is missing from the second record
+```
+
 ### Merge records with `//`
 Easily merge two records:
 

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,5 +1,5 @@
 { name = "record-studio"
-, dependencies = [ "heterogeneous", "lists", "prelude", "record" ]
+, dependencies = [ "heterogeneous", "lists", "prelude", "record", "typelevel-prelude" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs" ]
 , license = "MIT-0"

--- a/src/Record/Studio.purs
+++ b/src/Record/Studio.purs
@@ -5,11 +5,13 @@ module Record.Studio
   , module Record.Studio.Merge
   , module Record.Studio.Keys
   , module Record.Studio.Shrink
+  , module Record.Studio.SameKeys
   ) where
 
 import Record.Studio.Sequence (SequenceRecord(..), sequenceRecord)
 import Record.Studio.Map (MapRecord(..), mapRecord)
 import Record.Studio.MapKind (MapRecordKind(..), mapRecordKind)
-import Record.Studio.Keys (class Keys, recordKeys)
+import Record.Studio.Keys (class Keys, keys, recordKeys)
 import Record.Studio.Shrink (shrink)
 import Record.Studio.Merge (mergeFlipped, (//))
+import Record.Studio.SameKeys (class SameKeys)

--- a/src/Record/Studio/SameKeys.purs
+++ b/src/Record/Studio/SameKeys.purs
@@ -1,0 +1,44 @@
+module Record.Studio.SameKeys (class SameKeys, class SameKeysRL) where
+
+
+import Data.Symbol (class IsSymbol)
+import Prim.Row (class Lacks)
+import Prim.RowList (class RowToList)
+import Prim.RowList as RL
+import Prim.TypeError (class Fail, Beside, Quote, Text)
+import Type.RowList (class ListToRow)
+
+class SameKeys (r1 :: Row Type) (r2 :: Row Type)
+
+instance (RowToList r1 rl1, RowToList r2 rl2, SameKeysRL rl1 rl2) => SameKeys r1 r2
+
+class SameKeysRL (xs :: RL.RowList Type) (ys :: RL.RowList Type)
+
+instance SameKeysRL RL.Nil RL.Nil
+instance
+  ( IsSymbol name
+  , SameKeysRL tail1 tail2
+  ) =>
+  SameKeysRL (RL.Cons name ty1 tail1) (RL.Cons name ty2 tail2)
+else instance
+  ( ListToRow RL.Nil r
+  , Fail (Beside (Text "The key ") (Beside (Quote name) (Text " is missing from the second record")))
+  ) =>
+  SameKeysRL (RL.Cons name ty tail) RL.Nil
+else instance
+  ( ListToRow RL.Nil r
+  , Fail (Beside (Text "The key ") (Beside (Quote name) (Text " is missing from the first record")))
+  ) =>
+  SameKeysRL RL.Nil (RL.Cons name ty tail)
+else instance
+  ( ListToRow (RL.Cons name2 ty1 tail1) r
+  , Lacks name1 r
+  , Fail (Beside (Text "The key ") (Beside (Quote name1) (Text " is missing from the second record")))
+  ) =>
+  SameKeysRL (RL.Cons name1 ty1 tail1) (RL.Cons name2 ty2 tail2)
+else instance
+  ( ListToRow (RL.Cons name1 ty1 tail1) r
+  , Lacks name2 r
+  , Fail (Beside (Text "The key ") (Beside (Quote name2) (Text " is missing from the first record")))
+  ) =>
+  SameKeysRL (RL.Cons name1 ty1 tail1) (RL.Cons name2 ty2 tail2)

--- a/src/Record/Studio/Shrink.purs
+++ b/src/Record/Studio/Shrink.purs
@@ -1,17 +1,10 @@
 module Record.Studio.Shrink (shrink) where
 
 import Prim.Row (class Union)
-import Prim.RowList (class RowToList)
-import Record.Studio.Keys (class Keys, recordKeys)
+import Record.Studio.Keys (class Keys, keys)
 import Type.Proxy (Proxy(..))
 
 foreign import shrinkImpl :: forall r1 r2. Array String -> Record r1 -> Record r2
 
-shrink
-  :: forall a b bl r
-   . RowToList b bl
-  => Union b r a
-  => Keys bl
-  => Record a
-  -> Record b
-shrink = shrinkImpl (recordKeys (Proxy :: _ b))
+shrink :: forall a b r. Union b r a => Keys b => { | a } -> { | b }
+shrink = shrinkImpl (keys (Proxy :: Proxy b))

--- a/test/SameKeysSpec.purs
+++ b/test/SameKeysSpec.purs
@@ -1,0 +1,28 @@
+module SameKeysSpec where
+
+import Prelude
+
+import Record.Studio.SameKeys (class SameKeys)
+import Test.Spec (Spec, describe, it)
+
+spec :: Spec Unit
+spec =
+  describe "same keys" do
+    it "asserts the same keys" do
+      -- let _ = sameKeys { b: "hi", a: 4, c: 4 } { b: "hu", a: "ha" }
+      -- The key "c" is missing from the second record
+
+      -- let _ = sameKeys { b: "hi", a: 4 } { b: "hu", a: "ha", c: 4 }
+      -- The key "c" is missing from the first record
+
+      -- let _ = sameKeys { b: "hi", a: 4 } { b: "hu" }
+      -- The key "a" is missing from the second record
+
+      -- let _ = sameKeys { b: "hi", a: 4 } { b: "hu" }
+      -- The key "a" is missing from the second record
+
+      let _ = sameKeys { b: "hi", z: 1 } { z: "", b: { c: false } }
+      pure unit
+
+sameKeys :: forall r1 r2. SameKeys r1 r2 => {|r1} -> {|r2} -> Unit
+sameKeys _ _ = unit


### PR DESCRIPTION
Adds a typeclass `SameKeys r1 r2` that asserts that two records have the same keys.